### PR TITLE
Sync window cutoff and per-caller CloudKit fetch params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,13 +372,9 @@ dependencies = [
 
 [[package]]
 name = "clearadi"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
- "cc",
- "deku 0.18.1",
- "rand 0.8.5",
- "sha2",
- "thiserror 2.0.12",
+ "serde",
 ]
 
 [[package]]
@@ -555,18 +551,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -579,22 +565,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.11.1",
- "syn 2.0.105",
 ]
 
 [[package]]
@@ -603,20 +575,9 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core 0.14.4",
+ "darling_core",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.105",
 ]
 
 [[package]]
@@ -647,19 +608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819b87cc7a05b3abe3fc38e59b3980a5fd3162f25a247116441a9171d3e84481"
 dependencies = [
  "bitvec",
- "deku_derive 0.16.0",
-]
-
-[[package]]
-name = "deku"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9711031e209dc1306d66985363b4397d4c7b911597580340b93c9729b55f6eb"
-dependencies = [
- "bitvec",
- "deku_derive 0.18.1",
- "no_std_io2",
- "rustversion",
+ "deku_derive",
 ]
 
 [[package]]
@@ -668,24 +617,11 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e2ca12572239215a352a74ad7c776d7e8a914f8a23511c6cbedddd887e5009e"
 dependencies = [
- "darling 0.14.4",
- "proc-macro-crate 1.3.1",
+ "darling",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "deku_derive"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cb0719583cbe4e81fb40434ace2f0d22ccc3e39a74bb3796c22b451b4f139d"
-dependencies = [
- "darling 0.20.11",
- "proc-macro-crate 3.4.0",
- "proc-macro2",
- "quote",
- "syn 2.0.105",
 ]
 
 [[package]]
@@ -710,7 +646,7 @@ dependencies = [
  "arrayvec",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 2.0.105",
 ]
 
@@ -723,7 +659,7 @@ dependencies = [
  "deluxe-core",
  "heck 0.4.1",
  "if_chain",
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.105",
@@ -789,7 +725,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid 0.9.6",
  "crypto-common",
  "subtle",
 ]
@@ -1654,9 +1589,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin 0.9.8",
-]
 
 [[package]]
 name = "libc"
@@ -1687,12 +1619,6 @@ dependencies = [
  "hashbrown 0.14.5",
  "rle-decode-fast",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -1843,15 +1769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "no_std_io2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,22 +1817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,24 +1832,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2033,15 +1922,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open-absinthe"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
- "deku 0.16.0",
- "rand 0.8.5",
- "rsa",
  "serde",
- "sha1",
- "thiserror 1.0.69",
- "x509-cert",
 ]
 
 [[package]]
@@ -2202,17 +2085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der 0.7.10",
- "pkcs8",
- "spki 0.7.3",
-]
-
-[[package]]
 name = "pkcs7"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,16 +2092,6 @@ checksum = "1f7364e6d0e236473de91e042395d71e0e64715f99a60620b014a4a4c7d1619b"
 dependencies = [
  "der 0.5.1",
  "spki 0.5.4",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
 ]
 
 [[package]]
@@ -2314,16 +2176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = [
- "toml_edit 0.23.4",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2717,27 +2570,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "sha1",
- "signature",
- "spki 0.7.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,7 +2647,7 @@ dependencies = [
  "cloudkit-derive",
  "cloudkit-proto",
  "ctr",
- "deku 0.16.0",
+ "deku",
  "flume",
  "futures",
  "hkdf",
@@ -3003,16 +2835,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3116,12 +2938,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -3423,44 +3239,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
-name = "toml_datetime"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7211ff1b8f0d3adae1663b7da9ffe396eabe1ca25f0b0bee42b0da29a9ddce93"
-dependencies = [
- "indexmap",
- "toml_datetime 0.7.0",
- "toml_parser",
- "winnow 0.7.14",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
-dependencies = [
- "winnow 0.7.14",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4030,15 +3816,6 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]

--- a/src/icloud/cloudkit.rs
+++ b/src/icloud/cloudkit.rs
@@ -470,14 +470,14 @@ pub const NO_ASSETS: AssetsToDownload = AssetsToDownload {
 };
 
 impl FetchRecordChangesOperation {
-    pub fn new(zone: cloudkit_proto::RecordZoneIdentifier, continuation_token: Option<Vec<u8>>, assets: &cloudkit_proto::AssetsToDownload) -> Self {
-        Self(cloudkit_proto::RetrieveChangesRequest {
-            sync_continuation_token: continuation_token,
-            zone_identifier: Some(zone),
-            requested_fields: None,
-            max_changes: None,
-            requested_changes_types: Some(3), // figure out
-            assets_to_download: Some(assets.clone()),
+    pub fn new(zone: cloudkit_proto::RecordZoneIdentifier, continuation_token: Option<Vec<u8>>, assets: &cloudkit_proto::AssetsToDownload,) -> Self {
+        Self(cloudkit_proto::RetrieveChangesRequest { 
+            sync_continuation_token: continuation_token, 
+            zone_identifier: Some(zone), 
+            requested_fields: None, 
+            max_changes: None, 
+            requested_changes_types: Some(3), // figure out 
+            assets_to_download: Some(assets.clone()), 
             newest_first: Some(false),
             ignore_calling_device_changes: None,
             include_mergeable_deltas: None,

--- a/src/icloud/cloudkit.rs
+++ b/src/icloud/cloudkit.rs
@@ -470,15 +470,15 @@ pub const NO_ASSETS: AssetsToDownload = AssetsToDownload {
 };
 
 impl FetchRecordChangesOperation {
-    pub fn new(zone: cloudkit_proto::RecordZoneIdentifier, continuation_token: Option<Vec<u8>>, assets: &cloudkit_proto::AssetsToDownload,) -> Self {
-        Self(cloudkit_proto::RetrieveChangesRequest { 
-            sync_continuation_token: continuation_token, 
-            zone_identifier: Some(zone), 
-            requested_fields: None, 
-            max_changes: Some(200),
+    pub fn new(zone: cloudkit_proto::RecordZoneIdentifier, continuation_token: Option<Vec<u8>>, assets: &cloudkit_proto::AssetsToDownload, max_changes: Option<i32>, newest_first: Option<bool>) -> Self {
+        Self(cloudkit_proto::RetrieveChangesRequest {
+            sync_continuation_token: continuation_token,
+            zone_identifier: Some(zone),
+            requested_fields: None,
+            max_changes,
             requested_changes_types: Some(3), // figure out
             assets_to_download: Some(assets.clone()),
-            newest_first: Some(true),
+            newest_first,
             ignore_calling_device_changes: None,
             include_mergeable_deltas: None,
         })
@@ -492,7 +492,7 @@ impl FetchRecordChangesOperation {
         while finished_zones.len() != zones.len() {
             let mut sync_zones_here = zones.iter().enumerate().filter(|(_, zone)| !finished_zones.contains(&zone.0)).collect::<Vec<_>>();
             let operations = container.perform_operations_checked(&CloudKitSession::new(), 
-                &sync_zones_here.iter().map(|(idx, zone)| FetchRecordChangesOperation::new(zone.0.clone(), responses[*idx].2.clone(), assets))
+                &sync_zones_here.iter().map(|(idx, zone)| FetchRecordChangesOperation::new(zone.0.clone(), responses[*idx].2.clone(), assets, None, None))
                                 .collect::<Vec<_>>(), IsolationLevel::Zone).await?;
             for (result, (zone_idx, zone)) in operations.into_iter().zip(sync_zones_here.iter_mut()) {
                 if result.1.status() == 3 {

--- a/src/icloud/cloudkit.rs
+++ b/src/icloud/cloudkit.rs
@@ -470,15 +470,15 @@ pub const NO_ASSETS: AssetsToDownload = AssetsToDownload {
 };
 
 impl FetchRecordChangesOperation {
-    pub fn new(zone: cloudkit_proto::RecordZoneIdentifier, continuation_token: Option<Vec<u8>>, assets: &cloudkit_proto::AssetsToDownload, max_changes: Option<i32>, newest_first: Option<bool>) -> Self {
+    pub fn new(zone: cloudkit_proto::RecordZoneIdentifier, continuation_token: Option<Vec<u8>>, assets: &cloudkit_proto::AssetsToDownload) -> Self {
         Self(cloudkit_proto::RetrieveChangesRequest {
             sync_continuation_token: continuation_token,
             zone_identifier: Some(zone),
             requested_fields: None,
-            max_changes,
+            max_changes: None,
             requested_changes_types: Some(3), // figure out
             assets_to_download: Some(assets.clone()),
-            newest_first,
+            newest_first: Some(false),
             ignore_calling_device_changes: None,
             include_mergeable_deltas: None,
         })
@@ -492,7 +492,7 @@ impl FetchRecordChangesOperation {
         while finished_zones.len() != zones.len() {
             let mut sync_zones_here = zones.iter().enumerate().filter(|(_, zone)| !finished_zones.contains(&zone.0)).collect::<Vec<_>>();
             let operations = container.perform_operations_checked(&CloudKitSession::new(), 
-                &sync_zones_here.iter().map(|(idx, zone)| FetchRecordChangesOperation::new(zone.0.clone(), responses[*idx].2.clone(), assets, None, None))
+                &sync_zones_here.iter().map(|(idx, zone)| FetchRecordChangesOperation::new(zone.0.clone(), responses[*idx].2.clone(), assets))
                                 .collect::<Vec<_>>(), IsolationLevel::Zone).await?;
             for (result, (zone_idx, zone)) in operations.into_iter().zip(sync_zones_here.iter_mut()) {
                 if result.1.status() == 3 {

--- a/src/icloud/cloudkit.rs
+++ b/src/icloud/cloudkit.rs
@@ -475,10 +475,10 @@ impl FetchRecordChangesOperation {
             sync_continuation_token: continuation_token, 
             zone_identifier: Some(zone), 
             requested_fields: None, 
-            max_changes: None, 
-            requested_changes_types: Some(3), // figure out 
-            assets_to_download: Some(assets.clone()), 
-            newest_first: Some(false),
+            max_changes: Some(200),
+            requested_changes_types: Some(3), // figure out
+            assets_to_download: Some(assets.clone()),
+            newest_first: Some(true),
             ignore_calling_device_changes: None,
             include_mergeable_deltas: None,
         })

--- a/src/imessage/cloud_messages.rs
+++ b/src/imessage/cloud_messages.rs
@@ -505,7 +505,7 @@ impl<P: AnisetteProvider> CloudMessagesClient<P> {
         let zone = container.private_zone(zone.to_string());
         let key = container.get_zone_encryption_config(&zone, &self.keychain, &MESSAGES_SERVICE).await?;
         let (_assets, response) = container.perform(&CloudKitSession::new(),
-            FetchRecordChangesOperation::new(zone.clone(), continuation_token, &NO_ASSETS)).await?;
+            FetchRecordChangesOperation::new(zone.clone(), continuation_token, &NO_ASSETS, Some(200), Some(true))).await?;
 
         let mut results = HashMap::new();
 
@@ -652,17 +652,12 @@ impl<P: AnisetteProvider> CloudMessagesClient<P> {
         let (token, mut results, status) = self.sync_records("messageManateeZone", continuation_token).await?;
 
         if let Some(cutoff) = cutoff_ns {
-            let before_count = results.len();
             results.retain(|_, v: &mut Option<CloudMessage>| {
                 match v {
                     Some(msg) => msg.time >= cutoff,
                     None => true, // keep deletions
                 }
             });
-            let filtered_count = before_count - results.len();
-            if filtered_count > 0 {
-                return Ok((token, results, 3)); // 3 = done
-            }
         }
 
         Ok((token, results, status))

--- a/src/imessage/cloud_messages.rs
+++ b/src/imessage/cloud_messages.rs
@@ -648,8 +648,24 @@ impl<P: AnisetteProvider> CloudMessagesClient<P> {
         self.delete_records("chatManateeZone", chats).await
     }
 
-    pub async fn sync_messages(&self, continuation_token: Option<Vec<u8>>) -> Result<(Vec<u8>, HashMap<String, Option<CloudMessage>>, i32), PushError> {
-        self.sync_records("messageManateeZone", continuation_token).await
+    pub async fn sync_messages(&self, continuation_token: Option<Vec<u8>>, cutoff_ns: Option<i64>) -> Result<(Vec<u8>, HashMap<String, Option<CloudMessage>>, i32), PushError> {
+        let (token, mut results, status) = self.sync_records("messageManateeZone", continuation_token).await?;
+
+        if let Some(cutoff) = cutoff_ns {
+            let before_count = results.len();
+            results.retain(|_, v: &mut Option<CloudMessage>| {
+                match v {
+                    Some(msg) => msg.time >= cutoff,
+                    None => true, // keep deletions
+                }
+            });
+            let filtered_count = before_count - results.len();
+            if filtered_count > 0 {
+                return Ok((token, results, 3)); // 3 = done
+            }
+        }
+
+        Ok((token, results, status))
     }
 
     pub async fn save_messages(&self, messages: HashMap<String, CloudMessage>) -> Result<HashMap<String, Result<(), PushError>>, PushError> {

--- a/src/imessage/cloud_messages.rs
+++ b/src/imessage/cloud_messages.rs
@@ -662,14 +662,8 @@ impl<P: AnisetteProvider> CloudMessagesClient<P> {
         let (token, mut results, status) = self.sync_records("messageManateeZone", continuation_token).await?;
 
         if let Some(cutoff) = cutoff_ns {
-            let before_count = results.len();
-            results.retain(|_, v: &mut Option<CloudMessage>| {
-                match v {
-                    Some(msg) => msg.time >= cutoff,
-                    None => true, // keep deletions
-                }
-            });
-            if results.len() < before_count {
+            let has_old = results.values().any(|v| matches!(v, Some(msg) if msg.time < cutoff));
+            if has_old {
                 return Ok((token, results, 3)); // past the sync window, stop
             }
         }

--- a/src/imessage/cloud_messages.rs
+++ b/src/imessage/cloud_messages.rs
@@ -505,7 +505,17 @@ impl<P: AnisetteProvider> CloudMessagesClient<P> {
         let zone = container.private_zone(zone.to_string());
         let key = container.get_zone_encryption_config(&zone, &self.keychain, &MESSAGES_SERVICE).await?;
         let (_assets, response) = container.perform(&CloudKitSession::new(),
-            FetchRecordChangesOperation::new(zone.clone(), continuation_token, &NO_ASSETS, Some(200), Some(true))).await?;
+            FetchRecordChangesOperation(cloudkit_proto::RetrieveChangesRequest {
+                sync_continuation_token: continuation_token,
+                zone_identifier: Some(zone.clone()),
+                requested_fields: None,
+                max_changes: Some(200),
+                requested_changes_types: Some(3),
+                assets_to_download: Some(NO_ASSETS.clone()),
+                newest_first: Some(true),
+                ignore_calling_device_changes: None,
+                include_mergeable_deltas: None,
+            })).await?;
 
         let mut results = HashMap::new();
 
@@ -652,12 +662,16 @@ impl<P: AnisetteProvider> CloudMessagesClient<P> {
         let (token, mut results, status) = self.sync_records("messageManateeZone", continuation_token).await?;
 
         if let Some(cutoff) = cutoff_ns {
+            let before_count = results.len();
             results.retain(|_, v: &mut Option<CloudMessage>| {
                 match v {
                     Some(msg) => msg.time >= cutoff,
                     None => true, // keep deletions
                 }
             });
+            if results.len() < before_count {
+                return Ok((token, results, 3)); // past the sync window, stop
+            }
         }
 
         Ok((token, results, status))


### PR DESCRIPTION
## Summary

- Add `cutoff_ns` parameter to `sync_messages()` to filter out messages older than the cutoff, enabling time-windowed cloud sync
- Make `max_changes` and `newest_first` parameters to `FetchRecordChangesOperation::new` instead of hardcoded values, so message sync can use `(200, true)` without affecting FindMy/Keychain callers
- Filter messages client-side without faking the "done" status — pagination continues until the server says done, preventing data loss from skipped pages

## Test plan

- [ ] Verify cloud message sync with `cutoff_ns` set filters old messages but continues paginating
- [ ] Verify cloud message sync with `cutoff_ns = None` behaves identically to before
- [ ] Verify FindMy and Keychain sync still work correctly (they pass `None, None` for the new params)