### PR TITLE
Make `passcode_generation` field optional when deserializing escrow metadata

### DIFF
--- a/src/icloud/keychain.rs
+++ b/src/icloud/keychain.rs
@@ -1107,6 +1107,7 @@ pub const KEYCHAIN_ZONES: &[&str] = &[
 pub struct EscrowMetadata {
     pub serial: String,
     pub build: String,
+    #[serde(default)]
     pub passcode_generation: u32,
     #[serde(rename = "com.apple.securebackup.timestamp")]
     pub timestamp: String,


### PR DESCRIPTION
Two of my devices (one original iPhone and a hackintosh) were not showing up as escrow bottles because their metadata did not have the `passcode_generation` field attached, which caused deserialization to fail, which then caused rustpush to skip it entirely. This marks the field as optional to make them show up properly.

The type of the field remains the same, serde will just set it to a default value if it's missing.
