### PR TITLE
Skip submitting validation data in `login_apple_delegates` if not provided by os_config

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -383,7 +383,7 @@ pub async fn login_apple_delegates<T: AnisetteProvider>(account: &AppleAccount<T
         }
     };
 
-    let validation_data = os_config.generate_validation_data().await?;
+    let validation_data = os_config.generate_validation_data().await;
 
     let base_headers = account.anisette.lock().await.get_headers().await?.clone();
     let mut anisette_headers: HeaderMap = base_headers.into_iter().map(|(a, b)| (HeaderName::from_str(&a).unwrap(), b.parse().unwrap())).collect();
@@ -392,17 +392,26 @@ pub async fn login_apple_delegates<T: AnisetteProvider>(account: &AppleAccount<T
         anisette_headers.insert("Cookie", HeaderValue::from_str(cookie).unwrap());
     }
 
-    let resp = REQWEST.post(os_config.get_login_url())
+    let mut req = REQWEST.post(os_config.get_login_url())
             .header("Accept-Encoding", "gzip")
             .header("User-Agent", os_config.get_normal_ua("com.apple.iCloudHelper/282"))
             .header("X-Mme-Client-Info", os_config.get_mme_clientinfo(&os_config.get_aoskit_version()))
-            .header("X-Mme-Nas-Qualify", base64_encode(&validation_data))
             .header("X-Apple-ADSID", adsid)
             .headers(anisette_headers.clone())
             .basic_auth(username, Some(pet))
-            .body(plist_to_string(&request)?)
-            .send()
-            .await?;
+            .body(plist_to_string(&request)?);
+
+    if let Ok(ref vd) = validation_data {
+        if !vd.is_empty() {
+            req = req.header("X-Mme-Nas-Qualify", base64_encode(vd));
+        } else {
+            debug!("Skipping validation data: generated data was empty");
+        }
+    } else {
+        debug!("Skipping validation data: result was an error: {:?}", validation_data.err());
+    }
+
+    let resp = req.send().await?;
     let text = resp.text().await?;
 
     let parsed = plist::Value::from_reader(Cursor::new(text.as_str()))?;

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -205,7 +205,7 @@ pub struct IDSDelegateResponse {
 #[derive(Deserialize)]
 pub struct MobileMeDelegateResponse {
     pub tokens: HashMap<String, String>,
-    #[serde(default)]
+    #[serde(alias = "com.apple.mobileme", default)]
     pub config: Dictionary,
 }
 


### PR DESCRIPTION
Allows usage of `login_apple_delegates` without providing validation data. If validation data is missing by the implementation or returns an error, the request will omit the header.
