### PR TITLE
Make `ActivationInfo` public for external access

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ use std::fmt::Debug;
 pub use icloud_auth::{DefaultAnisetteProvider, GenerateVerificationTokenRequest, default_provider, ArcAnisetteClient, LoginClientInfo, LoginState, AppleAccount, VerifyBody, TrustedPhoneNumber};
 
 pub use util::{DebugRwLock, DebugMutex};
-use activation::ActivationInfo;
+pub use activation::ActivationInfo;
 pub use aps::{APSConnectionResource, APSConnection, APSMessage, APSState};
 use async_trait::async_trait;
 pub use auth::{request_update_account, UpdateAccountFinish};


### PR DESCRIPTION
Necessary for implementations of `OSConfig` that reside outside the rustpush package, because of `build_activation_info`'s return type.