### PR TITLE
Broaden MP cache-invalidate to all messageprotection-* codes

### DIFF
--- a/src/imessage/aps_client.rs
+++ b/src/imessage/aps_client.rs
@@ -250,8 +250,12 @@ impl IMClient {
             target: Some(target),
             ..
         } = &payload {
-            if error_string == "ec-com.apple.messageprotection-802" {
-                // refreshing identity cache can fix this
+            if error_string.starts_with("ec-com.apple.messageprotection-") {
+                // refreshing identity cache can fix this; previously this only
+                // matched "-802" but the same recovery path also resolves "-6"
+                // (signature/decrypt verification failed) and other recoverable
+                // message-protection codes that indicate a stale per-device
+                // session key. See discussion in openbubbles-app#206.
                 let mut cache_lock = self.identity.cache.lock().await;
                 cache_lock.invalidate(&target, &sender);
             }


### PR DESCRIPTION
## What this changes

One-line behavioral change in `src/imessage/aps_client.rs` (command:120 error handling). Previously only `ec-com.apple.messageprotection-802` invalidated the per-pair identity cache; this PR broadens that to any `ec-com.apple.messageprotection-*` code.

```diff
- if error_string == "ec-com.apple.messageprotection-802" {
+ if error_string.starts_with("ec-com.apple.messageprotection-") {
      // refreshing identity cache can fix this
      let mut cache_lock = self.identity.cache.lock().await;
      cache_lock.invalidate(&target, &sender);
  }
```

## Why

Filed as OpenBubbles/openbubbles-app#206 (full investigation and log evidence there). Short version:

`messageprotection-6` (signature/decrypt verification failed) and `-802` (NGM count drift) are both downstream symptoms of the same root condition — the per-device session key in rustpush's identity cache is stale relative to what the recipient device actually has. The recovery path (invalidate the cached pair, force a fresh IDS lookup on next send) works for both.

Without this fix, MP-6 errors propagate to the Dart UI as `Message::Error` and are rendered as send failures, even when Apple's IDS already accepted and delivered the message to the chat recipient. This is especially visible for self-loop errors (`sP == tP`) — the user's own other devices rejecting the reflected copy — where every retry hits the same stale cached key and produces the same MP-6, so the user sees a permanent "failed to send" state on messages that actually delivered.

Evidence from one user's log over 9 hours:
- 81 MP-6 errors
- 100% self-loops (`sP == tP`)
- 23 distinct failing device-tokens, concentrated on ~5 stuck devices
- `fR: 200` on all of them — Apple acked delivery; the per-recipient decryption failed

## Tested by

⚠️ **Not tested locally.** I don't have a working OpenBubbles/iMessage setup to validate end-to-end. The change is small enough to reason about statically, but please review with that caveat in mind.

In particular, the assumption being made is that *every* `ec-com.apple.messageprotection-*` code is recoverable via cache invalidation. If there are MP codes that should *not* invalidate the cache (e.g. ones indicating the recipient is permanently gone, or where invalidation would trigger a tight retry loop), this would need a more targeted match — for example an allowlist of known recoverable codes, or excluding specific ones.

I marked this draft for that reason. Happy to narrow the match (e.g. just `-6` + `-802`) if `starts_with` is too broad.

## Alternative considered

A more semantically correct fix would be in `process_msg`: detect self-loop errors (`sP == this client's own handle`) and suppress them from being surfaced as `Message::Error` to the Dart layer at all, since the chat recipient already got the message. That would be a larger change and I wasn't sure of the right way to compare against the client's own registered handles in this code — happy to attempt that direction instead if preferred.

Refs: OpenBubbles/openbubbles-app#206