### PR TITLE
Add Cape carrier gateway fallback

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -674,7 +674,7 @@ impl CarrierAddress {
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct Carrier {
-    phone_number_registration_gateway_address: CarrierAddress,
+    phone_number_registration_gateway_address: Option<CarrierAddress>,
     carrier_entitlements: Option<CarrierEntitlements>,
 }
 
@@ -683,6 +683,7 @@ const CARRIER_CONFIG: &str = "https://itunes.apple.com/WebObjects/MZStore.woa/wa
 const HARDCODED_GATEWAYS: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
     HashMap::from([
         ("311588", "28818773"), // Cape Cellular (MVNO on AT&T) -> AT&T SMS gateway
+        ("310410", "28818773"), // AT&T US
     ])
 });
 
@@ -729,10 +730,11 @@ pub async fn get_gateways_for_mccmnc(mccmnc: &str) -> Result<CarrierConfig, Push
         .send().await?;
     
     let master: MasterList = plist::from_bytes(&data.bytes().await?)?;
+    let fallback_gateway = HARDCODED_GATEWAYS.get(mccmnc).copied();
     let my_carrier = match master.mobile_device_carriers_by_mcc_mnc.get(mccmnc) {
         Some(c) => c,
         None => {
-            if let Some(gateway) = HARDCODED_GATEWAYS.get(mccmnc) {
+            if let Some(gateway) = fallback_gateway {
                 return Ok(CarrierConfig {
                     gateway: gateway.to_string(),
                     carrier: None,
@@ -763,10 +765,19 @@ pub async fn get_gateways_for_mccmnc(mccmnc: &str) -> Result<CarrierConfig, Push
         info!("here {:?}", plist::from_bytes::<Value>(&out)?);
 
         let parsed_file: Carrier = plist::from_bytes(&out)?;
+        if let Some(gateway) = parsed_file.phone_number_registration_gateway_address.and_then(|gateway| gateway.vec().choose(&mut thread_rng()).cloned()) {
+            return Ok(CarrierConfig {
+                gateway,
+                carrier: parsed_file.carrier_entitlements,
+            })
+        }
+    }
+
+    if let Some(gateway) = fallback_gateway {
         return Ok(CarrierConfig {
-            gateway: parsed_file.phone_number_registration_gateway_address.vec().choose(&mut thread_rng()).ok_or(PushError::CarrierNotFound)?.clone(),
-            carrier: parsed_file.carrier_entitlements,
-        })
+            gateway: gateway.to_string(),
+            carrier: None,
+        });
     }
 
     Err(PushError::CarrierNotFound)

--- a/src/util.rs
+++ b/src/util.rs
@@ -680,6 +680,11 @@ struct Carrier {
 
 const CARRIER_CONFIG: &str = "https://itunes.apple.com/WebObjects/MZStore.woa/wa/com.apple.jingle.appserver.client.MZITunesClientCheck/version?languageCode=en";
 
+const HARDCODED_GATEWAYS: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
+    HashMap::from([
+        ("311588", "28818773"), // Cape Cellular (MVNO on AT&T) -> AT&T SMS gateway
+    ])
+});
 
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
@@ -724,7 +729,18 @@ pub async fn get_gateways_for_mccmnc(mccmnc: &str) -> Result<CarrierConfig, Push
         .send().await?;
     
     let master: MasterList = plist::from_bytes(&data.bytes().await?)?;
-    let my_carrier = master.mobile_device_carriers_by_mcc_mnc.get(mccmnc).ok_or(PushError::CarrierNotFound)?;
+    let my_carrier = match master.mobile_device_carriers_by_mcc_mnc.get(mccmnc) {
+        Some(c) => c,
+        None => {
+            if let Some(gateway) = HARDCODED_GATEWAYS.get(mccmnc) {
+                return Ok(CarrierConfig {
+                    gateway: gateway.to_string(),
+                    carrier: None,
+                });
+            }
+            return Err(PushError::CarrierNotFound);
+        }
+    };
 
     let mut my_bundles = my_carrier.get_bundles();
     my_bundles.shuffle(&mut thread_rng());


### PR DESCRIPTION
## Summary

Adds a static SMS gateway fallback for Cape Cellular's home PLMN (`311588`) to use AT&T's phone-number registration gateway (`28818773`).

Cape is an AT&T MVNO/eSIM carrier. On Android, `TelephonyManager.simOperator` reports Cape's SIM operator as `311588`, but Apple's carrier master list currently has no entry for that MCC/MNC. Because of that, `get_gateways_for_mccmnc("311588")` returns `CarrierNotFound` before OpenBubbles can attempt SMS phone-number registration.

This also handles carrier bundles that are present in Apple's master list but do not include `PhoneNumberRegistrationGatewayAddress`, falling back to explicit gateway overrides instead of failing plist deserialization.

## Evidence

- Device: Pixel 10 Pro XL / GrapheneOS on Cape eSIM
- `gsm.sim.operator.numeric`: `311588,`
- `gsm.operator.numeric`: `310410,`
- `gsm.sim.operator.alpha`: `Cape,`
- Registered LTE cell reports MCC/MNC `310/410` and `rRplmn=310410`
- Apple carrier master list has AT&T bundles under `310410`, but no `311588` entry
- Some `310410` bundles include `SupportedSIMs` for `311588` but do not include `PhoneNumberRegistrationGatewayAddress`
- Extracted `ATT_US_iPhone.ipcc` includes `PhoneNumberRegistrationGatewayAddress = 28818773`

## Behavior

For unknown MCC/MNCs, this keeps existing behavior unless the MCC/MNC has an explicit entry in `HARDCODED_GATEWAYS`.

For `311588`, it returns a `CarrierConfig` with the AT&T gateway and `carrier: None`. That should allow entitlement auth to fall back as unsupported, then let the SMS auth path use the AT&T gateway for phone-number registration.

For `310410`, if the selected Apple bundle lacks `PhoneNumberRegistrationGatewayAddress`, the code continues scanning other bundles and then falls back to `28818773` if none provide a gateway.

## Verification

Set up local fake FairPlay cert files using the same approach as `.github/workflows/build.yml`.

Passed locally:

- `cargo build --release --features 'macos-validation-data,remote-clearadi' --package rustpush --lib`
- `cargo build --release --features 'macos-validation-data,remote-anisette-v3' --package rustpush --lib`

Built and installed a local debug Android APK. It sent `REG-REQ` to gateway `28818773` successfully on Cape, confirming this fixes carrier lookup/plist parsing. The remaining `REG-RESP` timeout appears to be carrier/Apple reply-path behavior rather than gateway discovery.

Fixes: https://github.com/OpenBubbles/rustpush/issues/31