### PR TITLE
Update Anisette v3 provisioning dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "apple-private-apis"]
 	path = apple-private-apis
-	url = https://github.com/Xare123/apple-private-apis.git
+	url = https://github.com/OpenBubbles/apple-private-apis.git
 [submodule "open-absinthe"]
 	path = open-absinthe
 	url = git@github.com:OpenBubbles/OpenAbsinthe-Stub.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "apple-private-apis"]
 	path = apple-private-apis
-	url = git@github.com:OpenBubbles/apple-private-apis.git
+	url = https://github.com/Xare123/apple-private-apis.git
 [submodule "open-absinthe"]
 	path = open-absinthe
 	url = git@github.com:OpenBubbles/OpenAbsinthe-Stub.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/OpenBubbles/apple-private-apis.git
 [submodule "open-absinthe"]
 	path = open-absinthe
-	url = git@github.com:OpenBubbles/OpenAbsinthe-Stub.git
+	url = https://github.com/OpenBubbles/OpenAbsinthe-Stub.git

--- a/src/ids/user.rs
+++ b/src/ids/user.rs
@@ -804,19 +804,18 @@ impl IDSUser {
             .send(&REQWEST).await?
             .bytes().await?;
 
-        info!("Got alias response {}", str::from_utf8(&bytes).expect("Bytes to urtf8"));
-
         #[derive(Deserialize)]
         struct AliasResult {
-            alias: String,
+            #[serde(default)]
+            alias: Option<String>,
             status: u32,
         }
 
         let parsed: AliasResult = plist::from_bytes(&bytes)?;
-        *alias = Some(parsed.alias);
         if parsed.status != 0 {
             return Err(PushError::AliasError(parsed.status))
         }
+        *alias = Some(parsed.alias.ok_or(PushError::BadMsg)?);
 
         info!("Just took action {operation} on alias {} for handle {handle}", alias.as_ref().expect("No alias!"));
 


### PR DESCRIPTION
## Summary

Advance `apple-private-apis` to the Anisette v3 provisioning fix and keep the submodule URL on the official OpenBubbles repository.

This depends on OpenBubbles/apple-private-apis#6.

## Why

OpenBubbles setup can currently fail before 2FA when the SideStore provisioning service returns newer states such as `EndProvisioningError`. The dependency update parses those states, returns typed errors, and retries transient transport failures with bounded backoff.

## Validation

- `git diff --check` passes.
- The updated dependency chain compiled successfully for Android arm64 in both Alpha profile and debug OpenBubbles builds: [Actions run 30135397236](https://github.com/Xare123/openbubbles-app/actions/runs/30135397236).
- Device verification on a Pixel 10 Pro progressed through the previously failing Anisette exchange to Apple 2FA.

The focused parsing tests live in the dependency PR. Standalone Rust tests were not executed on the Windows host because the MSVC linker was unavailable.
